### PR TITLE
Compatibility with mods that increase the textures size.

### DIFF
--- a/HDSprites/AssetTexture.cs
+++ b/HDSprites/AssetTexture.cs
@@ -51,6 +51,13 @@ namespace HDSprites
                 this.HDTexture = Upscaler.Upscale(lowerTexture, cursorsFlag);
                 this.EXTexture = Upscaler.Upscale(upperTexture, cursorsFlag);
             }
+            else if (hdTexture != null && this.Height * this.Scale > hdTexture.Height)
+            {
+                Texture2D lowerTexture = new Texture2D(this.GraphicsDevice, this.Width, this.Height);
+                lowerTexture.SetData(0, lowerTexture.Bounds, data, 0, lowerTexture.Width * lowerTexture.Height);
+
+                this.HDTexture = Upscaler.Upscale(lowerTexture, false);
+            }
         }
 
         public void SetOriginalTexture(Texture2D texture)


### PR DESCRIPTION
Hi.
Some people were reporting invisible tools in Animal Husbandry,
I investigated the issue and found the problem was HDSprites.
I found the code and thought this mod is really interested, so I tried to fix the problem.
After some trial and error because I didn't understood the logic, I cleaned up my code and the final result is quite simple.
This code addition made your mod compatible with Animal Husbandry, and possible any another mod that increases any texture size.
Feel free to rewrite my code to incorporate it your way.
Best regards,
Digus